### PR TITLE
Disable CSRF protection (vkontakte ignores parts of OAuth specification)

### DIFF
--- a/lib/omniauth/strategies/vkontakte.rb
+++ b/lib/omniauth/strategies/vkontakte.rb
@@ -26,6 +26,7 @@ module OmniAuth
       }
 
       option :authorize_options, [:scope, :display]
+      option :provider_ignores_state, true
 
       uid { access_token.params['user_id'] }
 


### PR DESCRIPTION
Unfortunately VKontakte's programmers ignore some parts of OAuth2
specification and don't return 'state' parameter back to the client.

Disable state-based CSRF protection by setting option
:provider_ignores_state to true.

Signed-off-by: Yauhen Kharuzhy jekhor@gmail.com
