### PR TITLE
Add info_fields option

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ You can configure several options, which you pass in to the `provider` method vi
 * `display`: the display context to show the authentication page. Valid options include `page`, `popup` and `mobile`.
 * `lang`: specifies the language. Optional options include `ru`, `ua`, `be`, `en`, `es`, `fi`, `de`, `it`.
 * `image_size`: defines the size of the user's image. Valid options include `mini`(50x50), `bigger`(100x100) and `original`(200x200). Default is `mini`.
+* `info_fields`: specify which fields should be added to AuthHash when
+  getting the user's info. Value should be a comma-separated string as per http://vk.com/dev/fields.
 
 Here's an example of a possible configuration:
 

--- a/lib/omniauth/strategies/vkontakte.rb
+++ b/lib/omniauth/strategies/vkontakte.rb
@@ -96,6 +96,7 @@ module OmniAuth
       def info_options
         # http://vk.com/dev/fields
         fields = ['nickname', 'screen_name', 'sex', 'city', 'country', 'online', 'bdate', 'photo_50', 'photo_100', 'photo_200_orig']
+        fields.concat(options[:info_fields].split(',')) if options[:info_fields] 
         return fields.join(',')
       end
 


### PR DESCRIPTION
- Adds additional fields to Auth Hash as per http://vk.com/dev/fields
- Adds info_fields option, a comma-separated list with fields which should
  be added to Auth Hash
- Auth Hash contains default fields if option info_fields not specified
