### PR TITLE
Add x2-sized (HD/Retina) photos support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ You can configure several options, which you pass in to the `provider` method vi
 * `scope`: a comma-separated list of access permissions you want to request from the user. [Read the Vkontakte docs for more details](http://vk.com/dev/permissions)
 * `display`: the display context to show the authentication page. Valid options include `page`, `popup` and `mobile`.
 * `lang`: specifies the language. Optional options include `ru`, `ua`, `be`, `en`, `es`, `fi`, `de`, `it`.
-* `image_size`: defines the size of the user's image. Valid options include `mini`(50x50), `bigger`(100x100) and `original`(200x200). Default is `mini`.
+* `image_size`: defines the size of the user's image. Valid options include `mini`(50x50), `bigger`(100x100), `bigger_x2`(200x200), `original`(200x*) and `original_x2`(400x*). Default is `mini`.
 * `info_fields`: specify which fields should be added to AuthHash when
   getting the user's info. Value should be a comma-separated string as per http://vk.com/dev/fields.
 

--- a/lib/omniauth/strategies/vkontakte.rb
+++ b/lib/omniauth/strategies/vkontakte.rb
@@ -96,7 +96,7 @@ module OmniAuth
 
       def info_options
         # http://vk.com/dev/fields
-        fields = ['nickname', 'screen_name', 'sex', 'city', 'country', 'online', 'bdate', 'photo_50', 'photo_100', 'photo_200_orig']
+        fields = %w[nickname screen_name sex city country online bdate photo_50 photo_100 photo_200 photo_200_orig photo_400_orig]
         fields.concat(options[:info_fields].split(',')) if options[:info_fields] 
         return fields.join(',')
       end
@@ -111,8 +111,12 @@ module OmniAuth
           raw_info['photo_50']
         when 'bigger'
           raw_info['photo_100']
+        when 'bigger_x2'
+          raw_info['photo_200']
         when 'original'
           raw_info['photo_200_orig']
+        when 'original_x2'
+          raw_info['photo_400_orig']
         else
           raw_info['photo_50']
         end


### PR DESCRIPTION
This PR enables using two more kinds of user profile images: `200x200px` and `400x*px`.

They could be used for screens with `devicePixelRatio > 1` such as Retina.
