### PR TITLE
add option redirect_url for change default redirect_url

### DIFF
--- a/lib/omniauth/strategies/vkontakte.rb
+++ b/lib/omniauth/strategies/vkontakte.rb
@@ -97,11 +97,7 @@ module OmniAuth
       private
 
       def callback_url
-        if options.redirect_url.nil?
-          super
-        else
-          options.redirect_url
-        end
+        options.redirect_url || super
       end
 
       def info_options

--- a/lib/omniauth/strategies/vkontakte.rb
+++ b/lib/omniauth/strategies/vkontakte.rb
@@ -29,6 +29,8 @@ module OmniAuth
 
       option :authorize_options, [:scope, :display]
 
+      option :redirect_url, nil
+
       uid { raw_info['id'].to_s }
 
       # https://github.com/intridea/omniauth/wiki/Auth-Hash-Schema
@@ -93,6 +95,14 @@ module OmniAuth
       end
 
       private
+
+      def callback_url
+        if options.redirect_url.nil?
+          full_host + script_name + callback_path
+        else
+          options.redirect_url
+        end
+      end
 
       def info_options
         # http://vk.com/dev/fields

--- a/lib/omniauth/strategies/vkontakte.rb
+++ b/lib/omniauth/strategies/vkontakte.rb
@@ -98,7 +98,7 @@ module OmniAuth
 
       def callback_url
         if options.redirect_url.nil?
-          full_host + script_name + callback_path
+          super
         else
           options.redirect_url
         end


### PR DESCRIPTION
modified:   lib/omniauth/strategies/vkontakte.rb

Now you can use this option in settings

```Ruby
Rails.application.config.middleware.use OmniAuth::Builder do
  provider :vkontakte, app_id, secret, :scope => 'wall,friends,photos,status,email', :redirect_url => 'https://oauth.vk.com/blank.html', :display => 'mobile', :image_size => 'original',
           :provider_ignores_state => true, :client_options => {:ssl => {:ca_path => '/etc/ssl/certs'}}
end
```