### PR TITLE
Optimize city and country fetching

### DIFF
--- a/lib/omniauth/strategies/vkontakte.rb
+++ b/lib/omniauth/strategies/vkontakte.rb
@@ -15,7 +15,7 @@ module OmniAuth
     class Vkontakte < OmniAuth::Strategies::OAuth2
       class NoRawData < StandardError; end
 
-      API_VERSION = '5.2'
+      API_VERSION = '5.8'
 
       DEFAULT_SCOPE = ''
 
@@ -97,7 +97,7 @@ module OmniAuth
       def info_options
         # http://vk.com/dev/fields
         fields = %w[nickname screen_name sex city country online bdate photo_50 photo_100 photo_200 photo_200_orig photo_400_orig]
-        fields.concat(options[:info_fields].split(',')) if options[:info_fields] 
+        fields.concat(options[:info_fields].split(',')) if options[:info_fields]
         return fields.join(',')
       end
 
@@ -122,38 +122,10 @@ module OmniAuth
         end
       end
 
-      # http://vk.com/dev/database.getCountriesById
-      def get_country
-        if raw_info['country'] && raw_info['country'] != "0"
-          params = {
-            :country_ids => raw_info['country'],
-            :lang        => lang_option,
-            :v           => API_VERSION,
-          }
-          country = access_token.get('/method/database.getCountriesById', :params => params).parsed['response']
-          country && country.first ? country.first['title'] : ''
-        else
-          ''
-        end
-      end
-
-      # http://vk.com/dev/database.getCitiesById
-      def get_city
-        if raw_info['city'] && raw_info['city'] != "0"
-          params = {
-            :city_ids => raw_info['city'],
-            :lang     => lang_option,
-            :v        => API_VERSION,
-          }
-          city = access_token.get('/method/database.getCitiesById', :params => params).parsed['response']
-          city && city.first ? city.first['title'] : ''
-        else
-          ''
-        end
-      end
-
       def location
-        @location ||= [get_country, get_city].map(&:strip).reject(&:empty?).join(', ')
+        country = raw_info.fetch('country', {})['title']
+        city = raw_info.fetch('city', {})['title']
+        @location ||= [country, city].compact.join(', ')
       end
 
       def callback_phase


### PR DESCRIPTION
I have encountered a strange problem: sometimes authorization takes about 75s. I have made a research and found that this gem makes redundant requests for city and country fetching. 

![screen_shot_2015-10-14_at_03_34_27](https://cloud.githubusercontent.com/assets/854386/10481526/c633d8c8-7279-11e5-8bf3-10a83b134990.png)

API version 5.8 provides titles of city and country in the ```users.get``` request.

Also, sometimes ```getCountry``` request takes to long and unicorn workers died by timeout.
![screen_shot_2015-10-14_at_03_57_31](https://cloud.githubusercontent.com/assets/854386/10481451/53e61376-7279-11e5-8c25-de7f5bdc10dd.png)

In this pull request I have optimized location fetching. It only makes ```users.get``` request, so its became about 2X faster.
![screen shot 2015-10-14 at 13 32 43](https://cloud.githubusercontent.com/assets/854386/10481613/56e039d4-727a-11e5-8c41-e6b542b24337.png)

