### PR TITLE
Add https option support

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ You can configure several options, which you pass in to the `provider` method vi
 * `info_fields`: specify which fields should be added to AuthHash when
   getting the user's info. Value should be a comma-separated string as per http://vk.com/dev/fields.
 * `redirect_url`: URL where code will be passed. This URL shall be a part of the domain specified in application settings http://vk.com/dev/auth_sites.
+* `https`: 1 - allows you to receive https links to photos and other media. 0 - return an http links (the default).
 
 Here's an example of a possible configuration:
 
@@ -36,6 +37,7 @@ use OmniAuth::Builder do
       :scope => 'friends,audio,photos',
       :display => 'popup',
       :lang => 'en',
+      :https => 1,
       :image_size => 'original'
     }
 end

--- a/lib/omniauth/strategies/vkontakte.rb
+++ b/lib/omniauth/strategies/vkontakte.rb
@@ -60,6 +60,7 @@ module OmniAuth
           params = {
             :fields   => info_options,
             :lang     => lang_option,
+            :https    => https_option,
             :v        => API_VERSION,
           }
 
@@ -107,6 +108,10 @@ module OmniAuth
 
       def lang_option
         options[:lang] || ''
+      end
+
+      def https_option
+        options[:https] || 0
       end
 
       def image_url


### PR DESCRIPTION
`https`: 1 - allows you to receive https links to photos and other media. 0 - return an http links (the default).