### PR TITLE
Allow omniauth-oauth2 of version 1.6 as well

### DIFF
--- a/omniauth-vkontakte.gemspec
+++ b/omniauth-vkontakte.gemspec
@@ -14,5 +14,5 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
   gem.version       = OmniAuth::Vkontakte::VERSION
 
-  gem.add_runtime_dependency 'omniauth-oauth2', '~> 1.5'
+  gem.add_runtime_dependency 'omniauth-oauth2', ['>= 1.5', '<= 1.6']
 end


### PR DESCRIPTION
I need this change to be able use other providers.
The change passes the tests (1.5, 1.6 individually).
The fixed version 1.6 works for me in production.