### PR TITLE
Update vk api version

### DIFF
--- a/lib/omniauth/strategies/vkontakte.rb
+++ b/lib/omniauth/strategies/vkontakte.rb
@@ -15,7 +15,7 @@ module OmniAuth
     class Vkontakte < OmniAuth::Strategies::OAuth2
       class NoRawData < StandardError; end
 
-      API_VERSION = '5.8'
+      API_VERSION = '5.107'
 
       DEFAULT_SCOPE = ''
 


### PR DESCRIPTION
Due deprecating old version of API (https://vk.com/dev/version_update_2.0), vkontakte started to reject with error requests with old api version (5.8 previously in code).
We started to get NoRawData exception.
I fixed only version. Now all working good.